### PR TITLE
Add basic tests

### DIFF
--- a/e2e/routes.test.ts
+++ b/e2e/routes.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('static pages', () => {
+  test('about page loads', async ({ page }) => {
+    await page.goto('/about-us');
+    await expect(page.locator('h1')).toContainText('About Us');
+  });
+
+  test('contact page displays form', async ({ page }) => {
+    await page.goto('/contact-us');
+    await expect(page.locator('form')).toBeVisible();
+  });
+
+  test('privacy policy page loads', async ({ page }) => {
+    await page.goto('/privacy-policy');
+    await expect(page.locator('h1')).toBeVisible();
+  });
+});
+
+test.describe('product pages', () => {
+  test('cw-air-th product page', async ({ page }) => {
+    await page.goto('/product/cw-air-th');
+    await expect(page.locator('h1')).toContainText('CropWatch Air Temperature');
+  });
+
+  test('cw-ss product page', async ({ page }) => {
+    await page.goto('/product/cw-ss');
+    await expect(page.locator('h1')).toContainText('CropWatch Soil Sensor');
+  });
+});

--- a/src/lib/components/vendor/animated-lines.spec.ts
+++ b/src/lib/components/vendor/animated-lines.spec.ts
@@ -1,0 +1,31 @@
+const globalAny: any = globalThis as any;
+if (!globalAny.window) { globalAny.window = { addEventListener() {}, removeEventListener() {} }; }
+
+import { describe, it, expect } from 'vitest';
+import LinkedParticles from './animated-lines.js';
+
+describe('LinkedParticles', () => {
+  it('initializes with the correct number of points', () => {
+    const ctx = {
+      canvas: {
+        width: 100,
+        height: 100,
+        addEventListener() {},
+        removeEventListener() {}
+      },
+      clearRect() {},
+      fillRect() {},
+      beginPath() {},
+      moveTo() {},
+      lineTo() {},
+      stroke() {},
+      closePath() {},
+      fill() {},
+      arc() {},
+      createLinearGradient() { return { addColorStop() {} }; }
+    } as unknown as CanvasRenderingContext2D;
+
+    const lp = new (LinkedParticles as any)(ctx);
+    expect(lp.points.length).toBe(lp.points_count);
+  });
+});

--- a/src/lib/data/products/cw-air-th.spec.ts
+++ b/src/lib/data/products/cw-air-th.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import cwAirThProduct from './cw-air-th';
+
+describe('cwAirThProduct', () => {
+  it('includes basic product info', () => {
+    expect(cwAirThProduct.name).toBe('CropWatch Air Temperature & Humidity Sensor');
+    expect(cwAirThProduct.models[0].id).toBe('CW-AIR-TH');
+  });
+
+  it('lists standout features', () => {
+    expect(cwAirThProduct.standoutFeatures.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/data/products/cw-ss.spec.ts
+++ b/src/lib/data/products/cw-ss.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import cwSSProduct from './cw-ss';
+
+describe('cwSSProduct', () => {
+  it('includes basic product info', () => {
+    expect(cwSSProduct.name).toBe('CropWatch Soil Sensor');
+    expect(cwSSProduct.models[0].id).toBe('CW-SS-TMEPNPK');
+  });
+
+  it('lists standout features', () => {
+    expect(cwSSProduct.standoutFeatures.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest unit tests for product data and vendor JS
- add Playwright checks for important pages

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_684cefb492e88320aaef238383020478