### PR TITLE
perf(io): self-host Inter/JetBrains fonts, geo-redirect JP traffic to…

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
 	},
 	"packageManager": "pnpm@10.18.2+sha512.9fb969fa749b3ade6035e0f109f0b8a60b5d08a1a87fdf72e337da90dcc93336e2280ca4e44f2358a649b83c17959e9993e777c2080879f3801e6f0d999ad3dd",
 	"dependencies": {
+		"@fontsource-variable/inter": "^5.2.8",
+		"@fontsource-variable/jetbrains-mono": "^5.2.8",
 		"botid": "^1.5.10",
 		"nodemailer": "^9.0.1"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       botid:
         specifier: ^1.5.10
         version: 1.5.10
@@ -683,6 +689,12 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fontsource-variable/inter@5.2.8':
+    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
 
   '@fontsource/fira-mono@5.2.7':
     resolution: {integrity: sha512-wYrAn6i3nH6luqQBZxtWUpl4UTUvs9AEbEeZxksPMwIqyjRRaxHTNW3c2VfM50gabS2IS7pT8lVWS2USB4ukYA==}
@@ -2919,6 +2931,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@fontsource-variable/inter@5.2.8': {}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@fontsource/fira-mono@5.2.7': {}
 

--- a/src/app.html
+++ b/src/app.html
@@ -4,8 +4,6 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/assets/logos/favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
 		<!-- Self-hosted icon font (subset, ~11 KB): preload so it's ready by first
 		     paint, then font-display:swap renders it with no flash or layout shift. -->
@@ -17,29 +15,11 @@
 			crossorigin
 		/>
 
-		<!-- Text faces (Inter + JetBrains Mono) load non-render-blocking: fetch the
-		     stylesheet as media="print" so it never blocks first paint, then flip
-		     it to "all" on load. display=swap pairs with the metric-matched
-		     'Inter Fallback' (see fonts.css) so the swap causes no reflow. Noto
-		     Sans JP is intentionally dropped - this English/Global site has only a
-		     few stray JP glyphs, which the system JP fonts in the stack cover. -->
-		<link
-			rel="preload"
-			as="style"
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
-		/>
-		<link
-			rel="stylesheet"
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
-			media="print"
-			onload="this.media='all'"
-		/>
-		<noscript>
-			<link
-				rel="stylesheet"
-				href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
-			/>
-		</noscript>
+		<!-- Text faces (Inter Variable + JetBrains Mono Variable) are self-hosted via
+		     @fontsource and imported in the root +layout.svelte, so they load
+		     same-origin (immutable-cached) with no third-party round-trip. The
+		     metric-matched 'Inter Fallback' (see fonts.css) still absorbs the swap so
+		     there's no reflow. -->
 		%sveltekit.head%
 	</head>
 	<body class="web" data-sveltekit-preload-data="hover">

--- a/src/lib/styles/tokens/fonts.css
+++ b/src/lib/styles/tokens/fonts.css
@@ -2,16 +2,17 @@
    CropWatch - Fonts (cropwatch.io / US-Global build)
    ============================================================
    Inter for UI + marketing, JetBrains Mono for data/readings,
-   Material Symbols Rounded for iconography. Loaded from Google
-   Fonts. The Japanese self-hosted faces are intentionally not
-   wired here - this is the English/Global site (.io). Japanese
-   glyphs, if any, fall through to Noto Sans JP.
+   Material Symbols Rounded for iconography. Inter + JetBrains Mono
+   are self-hosted (@fontsource-variable, imported in the root
+   +layout.svelte) so they load same-origin with no third-party
+   round-trip. Japanese glyphs, if any, fall through to the JP
+   stack (BIZ UDPGothic -> Yu Gothic -> Noto Sans JP).
    ============================================================ */
 
-/* The Inter / JetBrains Mono stylesheets are NOT @imported here. Buried this
-   deep (app.css -> design-system.css -> fonts.css -> Google) a remote @import
-   creates a serial request chain that blocks first paint, so those <link> tags
-   live in src/app.html where they are discovered immediately. */
+/* Inter Variable + JetBrains Mono Variable come in via JS imports in
+   +layout.svelte (import '@fontsource-variable/inter'), which Vite bundles into
+   the app CSS and rewrites to hashed, immutable, same-origin woff2 - no remote
+   @import chain, so first paint isn't blocked. */
 
 /* Material Symbols is self-hosted as a SUBSET (only the icons this site renders,
    ~11 KB vs the ~361 KB full static instance / ~5 MB variable font). It is

--- a/src/lib/styles/tokens/scales.css
+++ b/src/lib/styles/tokens/scales.css
@@ -23,7 +23,7 @@
 	/* Latin renders in Inter; Japanese glyphs fall through (per-glyph) to the
 	   Japanese default - BIZ UDPGothic (Morisawa BIZ UD Gothic, proportional,
 	   self-hosted & complete) - then Yu Gothic, then Hiragino / Noto Sans JP. */
-	--cw-font-family: 'Inter', 'Inter Fallback', 'BIZ UDPGothic', 'Yu Gothic', YuGothic,
+	--cw-font-family: 'Inter Variable', 'Inter Fallback', 'BIZ UDPGothic', 'Yu Gothic', YuGothic,
 		'游ゴシック', 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', sans-serif;
 	/* Japanese-only stack (use when an element is known to hold JP text) */
 	--cw-font-jp: 'BIZ UDPGothic', 'Yu Gothic', YuGothic, '游ゴシック',
@@ -31,7 +31,7 @@
 	/* Fixed-width (tategaki/tabular) Japanese - BIZ UDGothic, mono-spaced UD */
 	--cw-font-jp-tabular: 'BIZ UDGothic', 'BIZ UDPGothic', 'Yu Gothic',
 		'Hiragino Kaku Gothic ProN', 'Noto Sans JP', monospace;
-	--cw-font-mono: 'JetBrains Mono', 'Fira Mono', 'Cascadia Code', monospace;
+	--cw-font-mono: 'JetBrains Mono Variable', 'Fira Mono', 'Cascadia Code', monospace;
 
 	--cw-text-xs: 0.75rem;
 	--cw-text-sm: 0.875rem;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,10 @@
 	import Footer from '$lib/components/Footer.svelte';
 	import Analytics from '$lib/components/Analytics.svelte';
 	import { alternatesFor } from '$lib/seo/alternates';
+	// Self-hosted text faces (replace the former Google Fonts <link>s in app.html):
+	// same-origin, immutable-cached, no third-party connection blocking first paint.
+	import '@fontsource-variable/inter';
+	import '@fontsource-variable/jetbrains-mono';
 	import '../app.css';
 
 	let { children } = $props();

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,14 @@
       "Japan-website": false
     }
   },
+  "redirects": [
+    {
+      "source": "/:path((?!149e9513-01fa-4fb0-aad4-566afd725d1b).*)",
+      "has": [{ "type": "header", "key": "x-vercel-ip-country", "value": "JP" }],
+      "destination": "https://cropwatch.co.jp/",
+      "permanent": false
+    }
+  ],
   "rewrites": [
     {
       "source": "/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/a-4-a/c.js",


### PR DESCRIPTION
… .co.jp

- Replace the render-path Google Fonts (Inter + JetBrains Mono) with self-hosted @fontsource-variable faces imported in the root layout; drop the fonts.googleapis/gstatic <link>s + preconnects from app.html. Fonts now load same-origin, immutable-cached, with no third-party connection before first paint.
- Add a header-conditional (x-vercel-ip-country=JP) redirect in vercel.json so Japan traffic to cropwatch.io is sent to cropwatch.co.jp; US/other visitors keep the English .io site. Takes effect once the unconditional www->co.jp redirect is removed in the Vercel dashboard.